### PR TITLE
Update usage.sh

### DIFF
--- a/usage.sh
+++ b/usage.sh
@@ -83,6 +83,10 @@ while [[ $# -gt 0 ]]; do
             JSON_MODE=true
             shift
             ;;
+        -*)
+            echo -e "${RED}Error: Unknown option '$1'${RESET}"
+            show_help
+            ;;
         *)
             if [ -z "$WEBSITE_ID" ]; then
                 WEBSITE_ID="$1"


### PR DESCRIPTION
This change makes sure that if the command line switch/argument is mistyped then help is shown. instead of dumping the user out with "Error: Website ID --jso not found.